### PR TITLE
Fix broken JSON URLs

### DIFF
--- a/Samples/Line Layer/Display isoline data/Display isoline data.html
+++ b/Samples/Line Layer/Display isoline data/Display isoline data.html
@@ -20,7 +20,7 @@
         var map, datasource;
 
         //Earthquake intensity contours of M7.0 – 1km WSW of Kumamoto-shi, Japan (GeoJson source from usgs.gov: https://earthquake.usgs.gov/data/shakemap/)
-        var contourLineDataUrl = 'https://earthquake.usgs.gov/archive/product/shakemap/us20005iis/us/1467057010522/download/cont_psa03.json';
+        var contourLineDataUrl = 'https://earthquake.usgs.gov/product/shakemap/us20005iis/us/1467057010522/download/cont_psa03.json';
 
         function GetMap() {
             //Initialize a map instance.

--- a/Samples/Spatial Math/Create isobands from isolines/Create isobands from isolines.html
+++ b/Samples/Spatial Math/Create isobands from isolines/Create isobands from isolines.html
@@ -23,7 +23,7 @@
         var map, datasource;
 
         //Earthquake intensity contours of M7.0 – 1km WSW of Kumamoto-shi, Japan (GeoJson source from usgs.gov: https://earthquake.usgs.gov/data/shakemap/)
-        var contourLineDataUrl = 'https://earthquake.usgs.gov/archive/product/shakemap/us20005iis/us/1467057010522/download/cont_psa03.json';
+        var contourLineDataUrl = 'https://earthquake.usgs.gov/product/shakemap/us20005iis/us/1467057010522/download/cont_psa03.json';
 
         function GetMap() {
             //Initialize a map instance.


### PR DESCRIPTION
It turned out the existing JSON file URL has no longer available on USGS, and I have updated the new URLs of these files.

Affected samples:
1. https://samples.azuremaps.com/line-layer/display-isoline-data
2. https://samples.azuremaps.com/spatial-math/create-isobands-from-isolines