### PR TITLE
Fix typo in style option for custom navigation controls

### DIFF
--- a/Samples/Controls/Custom navigation controls/Custom navigation controls.html
+++ b/Samples/Controls/Custom navigation controls/Custom navigation controls.html
@@ -153,7 +153,7 @@
                 <option value="road" selected="selected">Road</option>
                 <option value="grayscale_dark">Dark Grayscale</option>
                 <option value="grayscale_light">Light Grayscale</option>
-                <option value="nighty">Night</option>
+                <option value="night">Night</option>
                 <option value="satellite">Satellite</option>
                 <option value="satellite_road_labels">Hybrid</option>
             </select>


### PR DESCRIPTION
The option value should be `night` instead of `nighty`.