### PR TITLE
Fix deck.gl version

### DIFF
--- a/Samples/3D-layer/deck.gl/deck.gl.html
+++ b/Samples/3D-layer/deck.gl/deck.gl.html
@@ -17,7 +17,7 @@
     <script src="https://atlas.microsoft.com/sdk/javascript/mapcontrol/3/atlas.min.js"></script>
 
     <!-- deck.gl is a WebGL-powered framework for visual exploratory data analysis of large datasets. -->
-    <script src="https://unpkg.com/deck.gl@latest/dist.min.js"></script>
+    <script src="https://unpkg.com/deck.gl@^8/dist.min.js"></script>
 
     <script>
         var map;


### PR DESCRIPTION
[decl.gl V9 has deprecated the `MapboxLayer`](https://github.com/visgl/deck.gl/issues/8584). Set the version to v8 so we won't be affected by breaking changes from deck.gl.