### PR TITLE
Replace service module with rest helper

### DIFF
--- a/Samples/Tutorials/Route/Route to a destination.html
+++ b/Samples/Tutorials/Route/Route to a destination.html
@@ -17,8 +17,8 @@
     <link href="https://atlas.microsoft.com/sdk/javascript/mapcontrol/3/atlas.min.css" rel="stylesheet" />
     <script src="https://atlas.microsoft.com/sdk/javascript/mapcontrol/3/atlas.min.js"></script>
 
-    <!-- Add a reference to the Azure Maps Services Module JavaScript file. -->
-    <script src="https://atlas.microsoft.com/sdk/javascript/service/2/atlas-service.min.js"></script>
+    <!-- Add a reference to the Azure Maps Rest Helper JavaScript file. -->
+    <script src="https://samples.azuremaps.com/lib/azure-maps/azure-maps-helper.min.js"></script>
 
     <script>
         var map, datasource, client;
@@ -26,7 +26,7 @@
         function GetMap() {
 
             // Instantiate a map object
-            var map = new atlas.Map('myMap', {
+            map = new atlas.Map('myMap', {
                 view: 'Auto',
 
                 //Add authentication details for connecting to Azure Maps.
@@ -95,20 +95,26 @@
                     padding: 80
                 });
 
-                //Use MapControlCredential to share authentication between a map control and the service module.
-                var pipeline = atlas.service.MapsURL.newPipeline(new atlas.service.MapControlCredential(map));
-
-                //Construct the RouteURL object
-                var routeURL = new atlas.service.RouteURL(pipeline);
-
-                //Start and end point input to the routeURL
-                var coordinates = [[startPoint.geometry.coordinates[0], startPoint.geometry.coordinates[1]], [endPoint.geometry.coordinates[0], endPoint.geometry.coordinates[1]]];
+                var query = startPoint.geometry.coordinates[1] + "," +
+                            startPoint.geometry.coordinates[0] + ":" +
+                            endPoint.geometry.coordinates[1] + "," +
+                            endPoint.geometry.coordinates[0];
+                var url = `https://{azMapsDomain}/route/directions/json?api-version=1.0&query=${query}`;
 
                 //Make a search route request
-                routeURL.calculateRouteDirections(atlas.service.Aborter.timeout(10000), coordinates).then((directions) => {
-                    //Get data features from response
-                    var data = directions.geojson.getFeatures();
-                    datasource.add(data);
+                processRequest(url).then((response) => {
+                    var route = response.routes[0];
+                    //Create an array to store the coordinates of each turn
+                    var routeCoordinates = [];
+                    route.legs.forEach((leg) => {
+                        var legCoordinates = leg.points.map((point) => {
+                            return [point.longitude, point.latitude];
+                        });
+                        //Add each turn to the array
+                        routeCoordinates = routeCoordinates.concat(legCoordinates);
+                    });
+                    //Add route line to the datasource
+                    datasource.add(new atlas.data.Feature(new atlas.data.LineString(routeCoordinates)));
                 });
             });
         }

--- a/Samples/Tutorials/Search/Search for points of interest.html
+++ b/Samples/Tutorials/Search/Search for points of interest.html
@@ -17,14 +17,16 @@
     <link href="https://atlas.microsoft.com/sdk/javascript/mapcontrol/3/atlas.min.css" rel="stylesheet" />
     <script src="https://atlas.microsoft.com/sdk/javascript/mapcontrol/3/atlas.min.js"></script>
 
-    <!-- Add a reference to the Azure Maps Services Module JavaScript file. -->
-    <script src="https://atlas.microsoft.com/sdk/javascript/service/2/atlas-service.min.js"></script>
+    <!-- Add a reference to the Azure Maps Rest Helper JavaScript file. -->
+    <script src="https://samples.azuremaps.com/lib/azure-maps/azure-maps-helper.min.js"></script>
 
     <script>
+        var map;
+
         function GetMap() {
             
             // Instantiate a map object
-            var map = new atlas.Map('myMap', {
+            map = new atlas.Map('myMap', {
                 view: 'Auto',
 
                 //Add authentication details for connecting to Azure Maps.
@@ -66,32 +68,26 @@
 
                 map.layers.add(resultLayer);
 
-                //Use MapControlCredential to share authentication between a map control and the service module.
-                var pipeline = atlas.service.MapsURL.newPipeline(new atlas.service.MapControlCredential(map));
-
-                // Construct the SearchURL object
-                var searchURL = new atlas.service.SearchURL(pipeline);
-
                 var query = 'gasoline-station';
                 var radius = 9000;
                 var lat = 47.64452336193245;
                 var lon = -122.13687658309935;
+                var url = `https://{azMapsDomain}/search/poi/json?api-version=1.0&query=${query}&lat=${lat}&lon=${lon}&radius=${radius}`;
 
-                searchURL.searchPOI(atlas.service.Aborter.timeout(10000), query, {
-                    limit: 10,
-                    lat: lat,
-                    lon: lon,
-                    radius: radius,
-                    view: 'Auto'
-                }).then((results) => {
+                processRequest(url).then((response) => {
+                    var bounds = [];
 
-                    // Extract GeoJSON feature collection from the response and add it to the datasource
-                    var data = results.geojson.getFeatures();
+                    //Extract GeoJSON feature collection from the response and add it to the datasource
+                    var data = response.results.map((result) => {
+                        var position = [result.position.lon, result.position.lat];
+                        bounds.push(position);
+                        return new atlas.data.Feature(new atlas.data.Point(position), { ...result });
+                    });
                     datasource.add(data);
 
-                    // set camera to bounds to show the results
+                    //Set camera to bounds to show the results
                     map.setCamera({
-                        bounds: data.bbox,
+                        bounds: new atlas.data.BoundingBox.fromLatLngs(bounds),
                         zoom: 10,
                         padding: 15
                     });

--- a/Samples/Tutorials/Simple Store Locator/Simple Store Locator.html
+++ b/Samples/Tutorials/Simple Store Locator/Simple Store Locator.html
@@ -16,8 +16,8 @@
     <link href="https://atlas.microsoft.com/sdk/javascript/mapcontrol/3/atlas.min.css" rel="stylesheet" />
     <script src="https://atlas.microsoft.com/sdk/javascript/mapcontrol/3/atlas.min.js"></script>
 
-    <!-- Add a reference to the Azure Maps Services Module JavaScript file. -->
-    <script src="https://atlas.microsoft.com/sdk/javascript/service/2/atlas-service.min.js"></script>
+    <!-- Add a reference to the Azure Maps Rest Helper JavaScript file. -->
+    <script src="https://samples.azuremaps.com/lib/azure-maps/azure-maps-helper.min.js"></script>
 
     <!-- Add references to the store locator JavaScript and CSS files. -->
     <link rel="stylesheet" href="/tutorials/simple-store-locator/index.css" type="text/css" />

--- a/Samples/Tutorials/Truck Route/Multiple routes by mode of travel.html
+++ b/Samples/Tutorials/Truck Route/Multiple routes by mode of travel.html
@@ -17,8 +17,8 @@
     <link href="https://atlas.microsoft.com/sdk/javascript/mapcontrol/3/atlas.min.css" rel="stylesheet" />
     <script src="https://atlas.microsoft.com/sdk/javascript/mapcontrol/3/atlas.min.js"></script>
 
-    <!-- Add a reference to the Azure Maps Services Module JavaScript file. -->
-    <script src="https://atlas.microsoft.com/sdk/javascript/service/2/atlas-service.min.js"></script>
+    <!-- Add a reference to the Azure Maps Rest Helper JavaScript file. -->
+    <script src="https://samples.azuremaps.com/lib/azure-maps/azure-maps-helper.min.js"></script>
 
     <script>
         var map, datasource, client;
@@ -26,7 +26,7 @@
         function GetMap() {
 
             // Create a new map
-            var map = new atlas.Map('myMap', {
+            map = new atlas.Map('myMap', {
                 view: 'Auto',
 
                 //Add authentication details for connecting to Azure Maps.
@@ -100,47 +100,56 @@
 
                 });
 
-                //Use MapControlCredential to share authentication between a map control and the service module.
-                var pipeline = atlas.service.MapsURL.newPipeline(new atlas.service.MapControlCredential(map));
-
-                //Construct the RouteURL object
-                var routeURL = new atlas.service.RouteURL(pipeline);
-
-                //Start and end point input to the routeURL
-                var coordinates = [[startPoint.geometry.coordinates[0], startPoint.geometry.coordinates[1]], [endPoint.geometry.coordinates[0], endPoint.geometry.coordinates[1]]];
+                //Start and end point input to the search route request
+                var query = startPoint.geometry.coordinates[1] + "," +
+                            startPoint.geometry.coordinates[0] + ":" +
+                            endPoint.geometry.coordinates[1] + "," +
+                            endPoint.geometry.coordinates[0];
 
                 //Make a search route request for a truck vehicle type
-                routeURL.calculateRouteDirections(atlas.service.Aborter.timeout(10000), coordinates, {
-                    travelMode: 'truck',
-                    vehicleWidth: 2,
-                    vehicleHeight: 2,
-                    vehicleLength: 5,
-                    vehicleLoadType: 'USHazmatClass2'
-                }).then((directions) => {
-                    //Get data features from response
-                    var data = directions.geojson.getFeatures();
-
-                    //Get the route line and add some style properties to it.  
-                    var routeLine = data.features[0];
-                    routeLine.properties.strokeColor = '#2272B9';
-                    routeLine.properties.strokeWidth = 9;
+                var truckRouteUrl = `https://{azMapsDomain}/route/directions/json?api-version=1.0&travelMode=truck&vehicleWidth=2&vehicleHeight=2&vehicleLength=5&vehicleLoadType=USHazmatClass2&query=${query}`;
+                processRequest(truckRouteUrl).then((response) => {
+                    var route = response.routes[0];
+                    //Create an array to store the coordinates of each turn
+                    var routeCoordinates = [];
+                    route.legs.forEach((leg) => {
+                        var legCoordinates = leg.points.map((point) => {
+                            return [point.longitude, point.latitude];
+                        });
+                        //Add each turn to the array
+                        routeCoordinates = routeCoordinates.concat(legCoordinates);
+                    });
 
                     //Add the route line to the data source. We want this to render below the car route which will likely be added to the data source faster, so insert it at index 0.
-                    datasource.add(routeLine, 0);
+                    datasource.add(
+                        new atlas.data.Feature(new atlas.data.LineString(routeCoordinates), {
+                            strokeColor: "#2272B9",
+                            strokeWidth: 9
+                        }),
+                        0
+                    );
                 });
 
-                routeURL.calculateRouteDirections(atlas.service.Aborter.timeout(10000), coordinates).then((directions) => {
+                var carRouteUrl = `https://atlas.microsoft.com/route/directions/json?api-version=1.0&query=${query}`;
+                processRequest(carRouteUrl).then((response) => {
+                    var route = response.routes[0];
+                    //Create an array to store the coordinates of each turn
+                    var routeCoordinates = [];
+                    route.legs.forEach((leg) => {
+                        var legCoordinates = leg.points.map((point) => {
+                            return [point.longitude, point.latitude];
+                        });
+                        //Add each turn to the array
+                        routeCoordinates = routeCoordinates.concat(legCoordinates);
+                    });
 
-                    //Get data features from response
-                    var data = directions.geojson.getFeatures();
-
-                    //Get the route line and add some style properties to it.  
-                    var routeLine = data.features[0];
-                    routeLine.properties.strokeColor = '#B76DAB';
-                    routeLine.properties.strokeWidth = 5;
-
-                    //Add the route line to the data source. We want this to render below the car route which will likely be added to the data source faster, so insert it at index 0.  
-                    datasource.add(routeLine);
+                    //Add the route line to the data source. This will add the car route after the truck route.
+                    datasource.add(
+                        new atlas.data.Feature(new atlas.data.LineString(routeCoordinates), {
+                            strokeColor: "#B76DAB",
+                            strokeWidth: 5
+                        })
+                    );
                 });
             });
         }


### PR DESCRIPTION
Replace service module with rest helper in the following samples:

- https://samples.azuremaps.com/?sample=search-for-points-of-interest
- https://samples.azuremaps.com/?sample=route-to-a-destination
- https://samples.azuremaps.com/?sample=multiple-routes-by-mode-of-travel
- https://samples.azuremaps.com/?sample=simple-store-locator

These samples are referenced in the MS Learn tutorials, with a PR update (https://github.com/MicrosoftDocs/azure-docs-pr/pull/272435) to remove mentions of the service module. 