### PR TITLE
Fix incorrect lat lon ordering

### DIFF
--- a/Samples/Tutorials/Search/Search for points of interest.html
+++ b/Samples/Tutorials/Search/Search for points of interest.html
@@ -93,7 +93,7 @@
                     //Extract GeoJSON feature collection from the response and add it to the datasource
                     var data = response.results.map((result) => {
                         var position = [result.position.lon, result.position.lat];
-                        bounds.push(position);
+                        bounds.push([result.position.lat, result.position.lon]);
                         return new atlas.data.Feature(new atlas.data.Point(position), { ...result });
                     });
                     datasource.add(data);


### PR DESCRIPTION
The camera view was incorrectly showing the ocean instead of Seattle when displaying search results.
![image](https://github.com/user-attachments/assets/1ff893c5-1d0e-4c03-884b-93fb2eb3f84c)

Changes Made:
- Modified the `bounds.push` call to use the correct coordinate format `[lat, lon]` as required by the `fromLatLngs` function, which sets the camera position.

Reason for the Change:
The `fromLatLngs` function expects coordinates in the `[lat, lon]` format. Previously, the code passed `[lon, lat]`, causing the camera to focus on an unintended location.

After modification:
![image](https://github.com/user-attachments/assets/4232a3ae-063e-4be9-80ec-585c7f6a67cd)
