### PR TITLE
fix: luminosity ratio of the focus indicator

### DIFF
--- a/Static/index.html
+++ b/Static/index.html
@@ -14,6 +14,10 @@
         .col {
             min-height: 350px
         }
+        
+        li.nav-item a.nav-link:focus {
+            outline: 2px solid #4382DF;
+        }
 
         a.m-skip-to-main {
             left: -999px;


### PR DESCRIPTION
Luminosity ratio of the focus indicator with respect to its background of the controls in header section is now greater than the required ratio 3:1.
![image](https://github.com/user-attachments/assets/e781e741-55e4-4e82-a1db-a14ffe3cb9e7)
