### PR TITLE
fix: carousel text truncated

### DIFF
--- a/Static/index.html
+++ b/Static/index.html
@@ -55,6 +55,25 @@
             a.m-skip-to-main:focus {
                 border: 1px dashed #000
             }
+
+        @media (max-width: 575.98px) {
+            .carousel-caption {
+                padding-bottom: 0 !important;
+            }
+
+            .carousel-caption p {
+                margin-bottom: 0.5rem !important;
+            }
+
+            .carousel-caption p a.btn {
+                font-size: 0.9rem !important;
+                padding: 0.2rem 0.4rem !important;
+            }
+
+            .carousel-indicators {
+                margin-bottom: 0.2rem !important;
+            }
+        }
     </style>
 </head>
 <body onload="Start()" class="d-flex flex-column h-100">


### PR DESCRIPTION
- Issue:
  After setting the viewport to 320*256, text present above 'Azure Maps Store Locator' & 'Azure Maps Demo' control is getting truncated.
- Fix:
  Apply smaller margin and padding when width < 576px (align with Boostrap) 
![image](https://github.com/user-attachments/assets/31daa5bc-dc12-4dfb-83d1-6f10df4960ed)
![image](https://github.com/user-attachments/assets/008692a8-6e30-4235-b9df-a111f414c110)
![image](https://github.com/user-attachments/assets/86c424c9-cabb-4609-9689-453fbf6c2413)
![image](https://github.com/user-attachments/assets/b60e93b1-44f1-4fe5-9c3b-5fad4d9b4613)
![image](https://github.com/user-attachments/assets/addf868a-8280-46b3-b1a9-cd8e839be30a)
