### PR TITLE
Fix: Add a delimited file (CSV) to the map

### DIFF
--- a/Samples/Spatial IO Module/Add a delimited file (CSV) to the map/Add a delimited file (CSV) to the map.html
+++ b/Samples/Spatial IO Module/Add a delimited file (CSV) to the map/Add a delimited file (CSV) to the map.html
@@ -61,6 +61,8 @@
                 //Read a CSV file from a URL or pass in a raw string.
                 atlas.io.read(delimitedFileUrl).then(r => {
                     if (r) {
+                        //Limit the number of features to be shown.
+                        r.features = r.features.slice(0, 1000);
                         //Add the feature data to the data source.
                         datasource.add(r);
 


### PR DESCRIPTION
Fixes https://samples.azuremaps.com/spatial-io-module/add-a-delimited-file-(csv)-to-the-map

Maplibre has a [known issue](https://github.com/maplibre/maplibre-gl-js/issues/2891) when displaying a large number of points that are close to each other.

Fixed by limiting the number of features to be shown.

![image](https://github.com/user-attachments/assets/73243ddd-af8b-42e6-afb8-f7ae37cdb858)
