### PR TITLE
fix: focus indicator in contrast theme

### DIFF
--- a/Static/index.html
+++ b/Static/index.html
@@ -15,6 +15,14 @@
             min-height: 350px
         }
 
+        /* Adjust the focus style for high contrast theme */
+        @media (forced-colors: active) {
+            .btn:focus {
+                outline: 2px solid #25cff2;
+                outline-offset: 0px;
+            }
+        }
+
         a.m-skip-to-main {
             left: -999px;
             position: absolute;


### PR DESCRIPTION
- Issue:
After applied contrast theme (Aquatic and Desert), focus indicator is not visible for 'Search' button.
Same issue repro for 'Azure maps and demo', 'Open GitHub project', 'Getting Started', and controls presents in card ('Run Sample', Open in New Tab' and Source code).
- Result:
Aquatic
![focus_aquatic](https://github.com/user-attachments/assets/270d3694-0479-456a-ad9f-f17765e1d9fa)
Dessert
![focus_dessert](https://github.com/user-attachments/assets/39607ae4-ccd7-4de7-a316-2cbe01304584)

