### PR TITLE
fix: search section is truncated

### DIFF
--- a/Static/index.html
+++ b/Static/index.html
@@ -61,6 +61,11 @@
         }
 
         @media (max-width: 575.98px) {
+            #navbarCollapse {
+                max-height: 80vh;
+                overflow-y: auto;
+            }
+
             .carousel-caption {
                 padding-bottom: 0 !important;
             }


### PR DESCRIPTION
- Issue:
When page viewport is set to 320x256px, Update and Search controls are getting truncated.
- Result:
![navbar_scroll](https://github.com/user-attachments/assets/12486148-e79b-495a-8416-d9272fbc8238)
