### PR TITLE
fix: luminosity ratio of indicator

### DIFF
--- a/Static/index.html
+++ b/Static/index.html
@@ -59,6 +59,10 @@
         a.m-skip-to-main:focus {
             border: 1px dashed #000
         }
+        
+        .btn-info:focus {
+            box-shadow: 0 0 0 0.25rem #226571;
+        }
 
         @media (max-width: 575.98px) {
             .carousel-caption {


### PR DESCRIPTION
- Issue:
Luminosity ratio of keyboard focus indicator on 'Open GitHub Project' control with background is less than 3:1.
- Result:
![螢幕擷取畫面 2025-03-25 152450](https://github.com/user-attachments/assets/f71d5001-da96-4af1-9171-1e05b0657f62)
