### PR TITLE
Fix typo for ScaleControl option

### DIFF
--- a/Samples/Controls/Simple Scale Bar Control/Simple Scale Bar Control.html
+++ b/Samples/Controls/Simple Scale Bar Control/Simple Scale Bar Control.html
@@ -49,12 +49,12 @@
                 map.controls.add([
                     //Add a imperial scale bar to the map.
                     new atlas.control.ScaleControl({
-                        units: 'imperial'
+                        unit: 'imperial'
                     }),
 
                     //Add a metric scale bar to the map.
                     new atlas.control.ScaleControl({
-                        units: 'metric'
+                        unit: 'metric'
                     })], {
                         position: 'bottom-left'
                     });


### PR DESCRIPTION
`units` is for 3rd party library. It should be `unit` for `ScaleControl` option.